### PR TITLE
feat: add initial tracking for macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,15 @@ wayland-client = "0.31.7"
 swayipc = "3.0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26.0"
-objc = "0.2.7"
+dispatch2 = "0.3"
+objc2 = "0.6.1"
+objc2-app-kit = "0.3.1"
+objc2-core-foundation = "0.3.1"
+objc2-core-graphics = "0.3.1"
+objc2-foundation = "0.3.1"
+objc2-av-foundation = "0.3.1"
+objc2-core-media = "0.3.1"
+objc2-core-video = "0.3.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.60.2", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,6 @@ dispatch2 = "0.3"
 objc2 = "0.6.1"
 objc2-app-kit = "0.3.1"
 objc2-core-foundation = "0.3.1"
-objc2-core-graphics = "0.3.1"
-objc2-foundation = "0.3.1"
-objc2-av-foundation = "0.3.1"
-objc2-core-media = "0.3.1"
-objc2-core-video = "0.3.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.60.2", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ mod platform;
 #[path = "windows/mod.rs"]
 mod platform;
 
-pub use platform::utils;
-
 pub use error::{FerrousFocusError, FerrousFocusResult};
 pub use focus_tracker::FocusTracker;
 pub use focused_window::{FocusedWindow, IconData};

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,4 +1,4 @@
-pub mod utils;
+mod utils;
 mod wayland_focus_tracker;
 mod xorg_focus_tracker;
 

--- a/src/macos/impl_focus_tracker.rs
+++ b/src/macos/impl_focus_tracker.rs
@@ -1,0 +1,234 @@
+use crate::{FerrousFocusError, FerrousFocusResult, FocusedWindow, IconData};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tracing::info;
+
+use super::utils;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ImplFocusTracker {}
+
+impl ImplFocusTracker {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ImplFocusTracker {
+    pub fn track_focus<F>(&self, on_focus: F) -> FerrousFocusResult<()>
+    where
+        F: FnMut(FocusedWindow) -> FerrousFocusResult<()>,
+    {
+        self.run(on_focus, None)
+    }
+
+    pub fn track_focus_with_stop<F>(
+        &self,
+        on_focus: F,
+        stop_signal: &AtomicBool,
+    ) -> FerrousFocusResult<()>
+    where
+        F: FnMut(FocusedWindow) -> FerrousFocusResult<()>,
+    {
+        self.run(on_focus, Some(stop_signal))
+    }
+
+    fn run<F>(&self, mut on_focus: F, stop_signal: Option<&AtomicBool>) -> FerrousFocusResult<()>
+    where
+        F: FnMut(FocusedWindow) -> FerrousFocusResult<()>,
+    {
+        // Track the previously focused app
+        let mut prev_process: Option<String> = None;
+        let mut prev_title: Option<String> = None;
+
+        // Set up the event loop
+        loop {
+            // Check stop signal before processing
+            if let Some(stop) = stop_signal {
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+
+            // Get the current focused window information
+            match get_focused_window_info() {
+                Ok((process, title, icon_data)) => {
+                    // Only report focus events when the application or title changes
+                    let focus_changed = match (&prev_process, &prev_title) {
+                        (Some(prev_proc), Some(prev_ttl)) => {
+                            *prev_proc != process || *prev_ttl != title
+                        }
+                        _ => true, // First run, always report
+                    };
+
+                    if focus_changed {
+                        // Convert icon data to IconData if available
+                        let icon = match icon_data {
+                            Some(data) => match convert_icon_to_icon_data(&data) {
+                                Ok(icon_data) => Some(icon_data),
+                                Err(e) => {
+                                    info!("Failed to convert icon data: {}", e);
+                                    None
+                                }
+                            },
+                            None => None,
+                        };
+
+                        // Create and send the focus event
+                        on_focus(FocusedWindow {
+                            process_id: None, // macOS doesn't easily provide PID from AppleScript
+                            process_name: Some(process.clone()),
+                            window_title: Some(title.clone()),
+                            icon,
+                        })?;
+
+                        // Update previous values
+                        prev_process = Some(process);
+                        prev_title = Some(title);
+                    }
+                }
+                Err(e) => {
+                    info!("Error getting window info: {}", e);
+                }
+            }
+
+            // Sleep to avoid high CPU usage (we can keep checking frequently)
+            std::thread::sleep(Duration::from_millis(500));
+        }
+
+        Ok(())
+    }
+}
+
+/* ------------------------------------------------------------ */
+/* Helper functions                                              */
+/* ------------------------------------------------------------ */
+
+/// Get information about the currently focused window
+fn get_focused_window_info() -> FerrousFocusResult<(String, String, Option<Vec<u32>>)> {
+    // Get the frontmost application name using AppleScript
+    let process = utils::get_frontmost_app_name().ok_or_else(|| {
+        FerrousFocusError::Platform("Failed to get frontmost application name".to_string())
+    })?;
+
+    // Get the frontmost window title
+    let title = utils::get_frontmost_window_title()
+        .unwrap_or_else(|| format!("{} (No window title)", process));
+
+    // Try to get the application icon
+    let icon_data = get_app_icon(&process).ok();
+
+    Ok((process, title, icon_data))
+}
+
+/// Get the application icon for a given process name
+fn get_app_icon(process_name: &str) -> FerrousFocusResult<Vec<u32>> {
+    // This is a simplified implementation using AppleScript to get the app icon
+    // In a real implementation, we would use NSImage and other Cocoa APIs
+
+    // Create a temporary file to save the icon
+    let temp_file = format!("/tmp/app_icon_{}.png", std::process::id());
+
+    // AppleScript to extract the application icon and save it to a file
+    let script = format!(
+        r#"
+        try
+            tell application "Finder"
+                set appPath to application file "{}" as alias
+                set appIcon to icon of appPath
+                set tempFolder to path to temporary items as string
+                set tempFile to "{}"
+
+                tell application "System Events"
+                    set iconFile to (make new file at tempFolder with properties {{name:tempFile}})
+                    set iconPath to path of iconFile
+                end tell
+
+                copy appIcon to iconFile
+                return POSIX path of iconPath
+            end tell
+        on error
+            return ""
+        end try
+        "#,
+        process_name, temp_file
+    );
+
+    // Execute the AppleScript
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| {
+            FerrousFocusError::Platform(format!("Failed to execute AppleScript: {}", e))
+        })?;
+
+    if !output.status.success() {
+        return Err(FerrousFocusError::Platform(
+            "AppleScript execution failed".to_string(),
+        ));
+    }
+
+    // Check if the icon file was created
+    let icon_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if icon_path.is_empty() {
+        return Err(FerrousFocusError::Platform(
+            "Failed to get application icon".to_string(),
+        ));
+    }
+
+    // For now, return a simple placeholder since we're removing image dependency
+    // In a real implementation, we would load and process the icon file
+    let _ = std::fs::remove_file(icon_path);
+
+    // Return placeholder icon data (width, height, then ARGB pixels)
+    Ok(vec![32, 32]) // Just width and height, no actual pixel data
+}
+
+/// Convert ARGB icon data to IconData
+fn convert_icon_to_icon_data(icon_data: &[u32]) -> FerrousFocusResult<IconData> {
+    if icon_data.len() < 2 {
+        return Err(FerrousFocusError::Platform("Invalid icon data".to_string()));
+    }
+
+    let width = icon_data[0] as usize;
+    let height = icon_data[1] as usize;
+
+    if width == 0 || height == 0 || width > 1024 || height > 1024 {
+        return Err(FerrousFocusError::Platform(
+            "Invalid icon dimensions".to_string(),
+        ));
+    }
+
+    // Convert ARGB to RGBA format
+    let mut pixels = Vec::with_capacity(width * height * 4);
+
+    for y in 0..height {
+        for x in 0..width {
+            let idx = 2 + (y * width + x);
+            if idx < icon_data.len() {
+                let argb = icon_data[idx];
+                let a = ((argb >> 24) & 0xFF) as u8;
+                let r = ((argb >> 16) & 0xFF) as u8;
+                let g = ((argb >> 8) & 0xFF) as u8;
+                let b = (argb & 0xFF) as u8;
+
+                // Store as RGBA
+                pixels.push(r);
+                pixels.push(g);
+                pixels.push(b);
+                pixels.push(a);
+            } else {
+                // Fill with transparent pixels if data is missing
+                pixels.extend_from_slice(&[0, 0, 0, 0]);
+            }
+        }
+    }
+
+    Ok(IconData {
+        width,
+        height,
+        pixels,
+    })
+}

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,1 +1,3 @@
+pub mod utils;
 
+pub mod impl_focus_tracker;

--- a/src/macos/utils.rs
+++ b/src/macos/utils.rs
@@ -1,25 +1,100 @@
-use std::process::Command;
+use crate::error::FerrousFocusResult;
+use objc2_app_kit::NSWorkspace;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
-/// Get the name of the frontmost application using AppleScript
-pub fn get_frontmost_app_name() -> Option<String> {
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg("tell application \"System Events\" to get name of first application process whose frontmost is true")
-        .output()
-        .ok()?;
+// Cache structure for reducing repeated API calls
+#[derive(Debug, Clone)]
+struct CachedResult {
+    value: String,
+    timestamp: Instant,
+}
 
-    if output.status.success() {
-        let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !name.is_empty() {
-            return Some(name);
+static APP_NAME_CACHE: OnceLock<Mutex<Option<CachedResult>>> = OnceLock::new();
+static WINDOW_TITLE_CACHE: OnceLock<Mutex<Option<CachedResult>>> = OnceLock::new();
+
+const CACHE_DURATION: Duration = Duration::from_millis(50); // 50ms cache for more responsive detection
+
+/// Get the name of the frontmost application using objc2 APIs
+pub fn get_frontmost_app_name() -> FerrousFocusResult<Option<String>> {
+    // Check cache first
+    let cache = APP_NAME_CACHE.get_or_init(|| Mutex::new(None));
+    if let Ok(cached) = cache.lock() {
+        if let Some(ref result) = *cached {
+            if result.timestamp.elapsed() < CACHE_DURATION {
+                return Ok(Some(result.value.clone()));
+            }
         }
     }
 
-    None
+    unsafe {
+        // Get shared workspace
+        let workspace = NSWorkspace::sharedWorkspace();
+        let frontmost_app = workspace.frontmostApplication();
+
+        if let Some(app) = frontmost_app {
+            if let Some(app_name) = app.localizedName() {
+                let name_str = app_name.to_string();
+
+                // Update cache
+                if let Ok(mut cached) = cache.lock() {
+                    *cached = Some(CachedResult {
+                        value: name_str.clone(),
+                        timestamp: Instant::now(),
+                    });
+                }
+
+                return Ok(Some(name_str));
+            }
+        }
+
+        Ok(None)
+    }
 }
 
-/// Get the title of the frontmost window using AppleScript
-pub fn get_frontmost_window_title() -> Option<String> {
+/// Get the title of the frontmost window using objc2 APIs
+pub fn get_frontmost_window_title() -> FerrousFocusResult<Option<String>> {
+    // Check cache first
+    let cache = WINDOW_TITLE_CACHE.get_or_init(|| Mutex::new(None));
+    if let Ok(cached) = cache.lock() {
+        if let Some(ref result) = *cached {
+            if result.timestamp.elapsed() < CACHE_DURATION {
+                return Ok(Some(result.value.clone()));
+            }
+        }
+    }
+
+    unsafe {
+        // Get shared workspace
+        let workspace = NSWorkspace::sharedWorkspace();
+        let frontmost_app = workspace.frontmostApplication();
+
+        if let Some(app) = frontmost_app {
+            // Try to get the window title using AppleScript as a fallback
+            // This is more reliable than accessibility APIs for basic window titles
+            let title = get_window_title_via_applescript().unwrap_or_else(|_| None);
+
+            if let Some(ref title_str) = title {
+                // Update cache
+                if let Ok(mut cached) = cache.lock() {
+                    *cached = Some(CachedResult {
+                        value: title_str.clone(),
+                        timestamp: Instant::now(),
+                    });
+                }
+            }
+
+            return Ok(title);
+        }
+
+        Ok(None)
+    }
+}
+
+/// Helper function to get window title via AppleScript
+unsafe fn get_window_title_via_applescript() -> FerrousFocusResult<Option<String>> {
+    use std::process::Command;
+
     let script = r#"
     tell application "System Events"
         set frontApp to first application process whose frontmost is true
@@ -40,16 +115,21 @@ pub fn get_frontmost_window_title() -> Option<String> {
         .arg("-e")
         .arg(script)
         .output()
-        .ok()?;
+        .map_err(|e| {
+            crate::error::FerrousFocusError::Platform(format!(
+                "Failed to execute AppleScript: {}",
+                e
+            ))
+        })?;
 
     if output.status.success() {
         let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !title.is_empty() {
-            return Some(title);
+            return Ok(Some(title));
         }
     }
 
-    None
+    Ok(None)
 }
 
 /// Check if the application is running in a sandboxed environment
@@ -58,35 +138,39 @@ pub fn is_app_sandboxed() -> bool {
     std::env::var("APP_SANDBOX_CONTAINER_ID").is_ok()
 }
 
-/// Get the bundle identifier for a given application name
-pub fn get_bundle_id_for_app(app_name: &str) -> Option<String> {
-    let script = format!(
-        r#"
-        try
-            tell application "Finder"
-                set appPath to POSIX path of (application file "{}" as alias)
-            end tell
+/// Get the bundle identifier for a given application name using objc2 APIs
+pub fn get_bundle_id_for_app(app_name: &str) -> FerrousFocusResult<Option<String>> {
+    unsafe {
+        // Get shared workspace
+        let workspace = NSWorkspace::sharedWorkspace();
+        let running_apps = workspace.runningApplications();
 
-            do shell script "mdls -name kMDItemCFBundleIdentifier -raw " & quoted form of appPath
-        on error
-            return ""
-        end try
-        "#,
-        app_name
-    );
+        for app in running_apps.iter() {
+            if let Some(localized_name) = app.localizedName() {
+                let name_str = localized_name.to_string();
+                if name_str == app_name {
+                    if let Some(bundle_id) = app.bundleIdentifier() {
+                        return Ok(Some(bundle_id.to_string()));
+                    }
+                }
+            }
+        }
 
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .output()
-        .ok()?;
+        Ok(None)
+    }
+}
 
-    if output.status.success() {
-        let bundle_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !bundle_id.is_empty() {
-            return Some(bundle_id);
+/// Clear all caches - useful for testing or when you need fresh data
+pub fn clear_caches() {
+    if let Some(cache) = APP_NAME_CACHE.get() {
+        if let Ok(mut cached) = cache.lock() {
+            *cached = None;
         }
     }
 
-    None
+    if let Some(cache) = WINDOW_TITLE_CACHE.get() {
+        if let Ok(mut cached) = cache.lock() {
+            *cached = None;
+        }
+    }
 }

--- a/src/macos/utils.rs
+++ b/src/macos/utils.rs
@@ -1,0 +1,92 @@
+use std::process::Command;
+
+/// Get the name of the frontmost application using AppleScript
+pub fn get_frontmost_app_name() -> Option<String> {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg("tell application \"System Events\" to get name of first application process whose frontmost is true")
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+
+    None
+}
+
+/// Get the title of the frontmost window using AppleScript
+pub fn get_frontmost_window_title() -> Option<String> {
+    let script = r#"
+    tell application "System Events"
+        set frontApp to first application process whose frontmost is true
+        set frontAppName to name of frontApp
+
+        tell process frontAppName
+            try
+                set windowTitle to name of first window
+                return windowTitle
+            on error
+                return ""
+            end try
+        end tell
+    end tell
+    "#;
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !title.is_empty() {
+            return Some(title);
+        }
+    }
+
+    None
+}
+
+/// Check if the application is running in a sandboxed environment
+pub fn is_app_sandboxed() -> bool {
+    // Check for the App Sandbox environment variable
+    std::env::var("APP_SANDBOX_CONTAINER_ID").is_ok()
+}
+
+/// Get the bundle identifier for a given application name
+pub fn get_bundle_id_for_app(app_name: &str) -> Option<String> {
+    let script = format!(
+        r#"
+        try
+            tell application "Finder"
+                set appPath to POSIX path of (application file "{}" as alias)
+            end tell
+
+            do shell script "mdls -name kMDItemCFBundleIdentifier -raw " & quoted form of appPath
+        on error
+            return ""
+        end try
+        "#,
+        app_name
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let bundle_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !bundle_id.is_empty() {
+            return Some(bundle_id);
+        }
+    }
+
+    None
+}

--- a/src/macos/utils.rs
+++ b/src/macos/utils.rs
@@ -13,7 +13,7 @@ struct CachedResult {
 static APP_NAME_CACHE: OnceLock<Mutex<Option<CachedResult>>> = OnceLock::new();
 static WINDOW_TITLE_CACHE: OnceLock<Mutex<Option<CachedResult>>> = OnceLock::new();
 
-const CACHE_DURATION: Duration = Duration::from_millis(50); // 50ms cache for more responsive detection
+const CACHE_DURATION: Duration = Duration::from_millis(500); // 500ms cache for more responsive detection
 
 /// Get the name of the frontmost application using objc2 APIs
 pub fn get_frontmost_app_name() -> FerrousFocusResult<Option<String>> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced macOS-specific focus tracking to monitor focused application windows and notify on changes.
  - Added utilities for retrieving frontmost app names, window titles, sandbox status, and app bundle identifiers on macOS.

- **Chores**
  - Added new modules to organize macOS-related functionality.
  - Updated macOS dependencies to use newer, modular Objective-C 2.0 bindings and related frameworks.
  - Adjusted module visibility and public exports for platform utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->