### PR TITLE
feat: add example to locally save tracked icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Cargo.lock
 *.md
 !./README.md
 
+examples/recorded_icons/*
+!examples/recorded_icons/.gitkeep

--- a/examples/focused_icon_tracking.rs
+++ b/examples/focused_icon_tracking.rs
@@ -1,0 +1,103 @@
+//! Simple example that tracks focus and saves the focused app's icon to a file
+//!
+//! This example demonstrates how to:
+//! 1. Track focus changes using FocusTracker
+//! 2. Extract IconData from the focused window
+//! 3. Save the icon as a PNG file for inspection
+//!
+//! Usage: cargo run --example focused_icon_display_simple
+
+use ferrous_focus::{FerrousFocusResult, FocusTracker, FocusedWindow, IconData};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::info;
+
+fn save_icon_to_file(
+    icon_data: &IconData,
+    filename: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if icon_data.pixels.is_empty() || icon_data.width == 0 || icon_data.height == 0 {
+        return Err("Invalid icon data".into());
+    }
+
+    // Create an image buffer from the icon data
+    let img = image::RgbaImage::from_raw(
+        icon_data.width as u32,
+        icon_data.height as u32,
+        icon_data.pixels.clone(),
+    )
+    .ok_or("Failed to create image from icon data")?;
+
+    // Save as PNG
+    img.save(filename)?;
+    info!("Saved icon to: {}", filename);
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    info!("Starting Focused App Icon Display (Simple) example...");
+    info!("This will track focus changes and save icons to PNG files.");
+    info!("Switch between different applications to see their icons saved!");
+    info!("Press Ctrl+C to exit gracefully.");
+
+    // Create a stop signal
+    let stop_signal = Arc::new(AtomicBool::new(false));
+    let stop_signal_clone = stop_signal.clone();
+
+    // Set up Ctrl+C handler
+    ctrlc::set_handler(move || {
+        info!("Received interrupt signal (Ctrl+C), shutting down gracefully...");
+        stop_signal_clone.store(true, Ordering::SeqCst);
+    })?;
+
+    // Create the focus tracker
+    let tracker = FocusTracker::new();
+
+    let mut icon_counter = 0;
+
+    // Start tracking focus
+    let result = tracker.track_focus_with_stop(
+        move |window: FocusedWindow| -> FerrousFocusResult<()> {
+            info!("Focus changed to: {:?}", window.window_title);
+            if let Some(process) = &window.process_name {
+                info!("  Process: {}", process);
+            }
+
+            // Handle the icon
+            if let Some(icon) = window.icon {
+                info!("  Icon: {}x{} pixels", icon.width, icon.height);
+
+                if icon.width > 0 && icon.height > 0 && !icon.pixels.is_empty() {
+                    icon_counter += 1;
+                    let filename = format!("examples/recorded_icons/icon_{:03}.png", icon_counter);
+
+                    match save_icon_to_file(&icon, &filename) {
+                        Ok(_) => {
+                            info!("  ✓ Icon saved successfully as {}", filename);
+                        }
+                        Err(e) => {
+                            info!("  ✗ Failed to save icon: {}", e);
+                        }
+                    }
+                } else {
+                    info!("  ✗ Icon data is empty or invalid");
+                }
+            } else {
+                info!("  ✗ No icon available");
+            }
+
+            Ok(())
+        },
+        &stop_signal,
+    );
+
+    match result {
+        Ok(_) => info!("Focus tracking completed successfully"),
+        Err(e) => info!("Focus tracking failed: {}", e),
+    }
+
+    info!("Example completed! Check the current directory for saved icon files.");
+    Ok(())
+}

--- a/src/linux/xorg_focus_tracker.rs
+++ b/src/linux/xorg_focus_tracker.rs
@@ -317,11 +317,6 @@ fn get_icon_data<C: Connection>(
     window: u32,
     net_wm_icon: u32,
 ) -> FerrousFocusResult<IconData> {
-    let mut icon_data = IconData {
-        width: 0,
-        height: 0,
-        pixels: Vec::new(),
-    };
     match conn.get_property(
         false,
         window,
@@ -337,22 +332,74 @@ fn get_icon_data<C: Connection>(
                         return Err(FerrousFocusError::Unsupported);
                     }
 
-                    // The icon data is an array of 8-bit values
-                    match reply.value8() {
-                        Some(values) => {
-                            let values = values.collect::<Vec<u8>>();
-                            let size = values.len();
-                            icon_data.width = size;
-                            icon_data.height = size;
-                            icon_data.pixels = values;
-                            Ok(icon_data)
+                    // The _NET_WM_ICON property contains 32-bit values in the format:
+                    // [width, height, pixel_data...]
+                    // Each pixel is ARGB in native endian format
+                    match reply.value32() {
+                        Some(mut values) => {
+                            let values: Vec<u32> = values.collect();
+
+                            if values.len() < 2 {
+                                return Err(FerrousFocusError::Platform(
+                                    "Invalid icon data: missing width/height".to_string(),
+                                ));
+                            }
+
+                            let width = values[0] as usize;
+                            let height = values[1] as usize;
+
+                            if width == 0 || height == 0 {
+                                return Err(FerrousFocusError::Platform(
+                                    "Invalid icon dimensions".to_string(),
+                                ));
+                            }
+
+                            let expected_pixels = width * height;
+                            let available_pixels = values.len() - 2; // Subtract width and height
+
+                            if available_pixels < expected_pixels {
+                                return Err(FerrousFocusError::Platform(format!(
+                                    "Insufficient pixel data: expected {}, got {}",
+                                    expected_pixels, available_pixels
+                                )));
+                            }
+
+                            // Convert ARGB u32 values to RGBA u8 bytes
+                            let mut pixels = Vec::with_capacity(expected_pixels * 4);
+                            for &argb in &values[2..2 + expected_pixels] {
+                                // Extract ARGB components (native endian)
+                                let a = ((argb >> 24) & 0xFF) as u8;
+                                let r = ((argb >> 16) & 0xFF) as u8;
+                                let g = ((argb >> 8) & 0xFF) as u8;
+                                let b = (argb & 0xFF) as u8;
+
+                                // Store as RGBA
+                                pixels.push(r);
+                                pixels.push(g);
+                                pixels.push(b);
+                                pixels.push(a);
+                            }
+
+                            Ok(IconData {
+                                width,
+                                height,
+                                pixels,
+                            })
                         }
-                        None => Err(FerrousFocusError::Unsupported),
+                        None => Err(FerrousFocusError::Platform(
+                            "Failed to parse icon data as 32-bit values".to_string(),
+                        )),
                     }
                 }
-                Err(err) => Err(FerrousFocusError::Error(err.to_string())),
+                Err(err) => Err(FerrousFocusError::Platform(format!(
+                    "Failed to get icon property: {}",
+                    err
+                ))),
             }
         }
-        Err(err) => Err(FerrousFocusError::Error(err.to_string())),
+        Err(err) => Err(FerrousFocusError::Platform(format!(
+            "Failed to request icon property: {}",
+            err
+        ))),
     }
 }

--- a/src/linux/xorg_focus_tracker.rs
+++ b/src/linux/xorg_focus_tracker.rs
@@ -336,7 +336,7 @@ fn get_icon_data<C: Connection>(
                     // [width, height, pixel_data...]
                     // Each pixel is ARGB in native endian format
                     match reply.value32() {
-                        Some(mut values) => {
+                        Some(values) => {
                             let values: Vec<u32> = values.collect();
 
                             if values.len() < 2 {

--- a/src/linux/xorg_focus_tracker.rs
+++ b/src/linux/xorg_focus_tracker.rs
@@ -354,7 +354,9 @@ fn get_icon_data<C: Connection>(
                                 ));
                             }
 
-                            let expected_pixels = width * height;
+                            let expected_pixels = width.checked_mul(height).ok_or_else(|| {
+                                FerrousFocusError::Platform("Icon dimensions overflow".into())
+                            })?;
                             let available_pixels = values.len() - 2; // Subtract width and height
 
                             if available_pixels < expected_pixels {
@@ -365,7 +367,11 @@ fn get_icon_data<C: Connection>(
                             }
 
                             // Convert ARGB u32 values to RGBA u8 bytes
-                            let mut pixels = Vec::with_capacity(expected_pixels * 4);
+                            let mut pixels = Vec::with_capacity(
+                                expected_pixels.checked_mul(4).ok_or_else(|| {
+                                    FerrousFocusError::Platform("Icon dimensions overflow".into())
+                                })?,
+                            );
                             for &argb in &values[2..2 + expected_pixels] {
                                 // Extract ARGB components (native endian)
                                 let a = ((argb >> 24) & 0xFF) as u8;

--- a/tests/integration_basic.rs
+++ b/tests/integration_basic.rs
@@ -96,7 +96,7 @@ fn test_basic_focus_tracking() {
                 }
                 Ok(())
             },
-            &*stop_signal_clone,
+            &stop_signal_clone,
         );
 
         match result {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -14,8 +14,8 @@ use tracing::info;
 /// A `Child` process handle for the spawned window
 pub fn spawn_test_window(title: &str) -> Result<Child, Box<dyn std::error::Error>> {
     let mut cmd = Command::new("cargo");
-    cmd.args(&["run", "--example", "spawn_window", "--"])
-        .args(&["--title", title])
+    cmd.args(["run", "--example", "spawn_window", "--"])
+        .args(["--title", title])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -28,32 +28,32 @@ pub fn spawn_test_window(title: &str) -> Result<Child, Box<dyn std::error::Error
     Ok(child)
 }
 
-/// Spawn a test window with an icon
-///
-/// # Arguments
-/// * `title` - The window title to set
-/// * `icon_path` - Path to the icon file
-///
-/// # Returns
-/// A `Child` process handle for the spawned window
-pub fn spawn_test_window_with_icon(
-    title: &str,
-    icon_path: &str,
-) -> Result<Child, Box<dyn std::error::Error>> {
-    let mut cmd = Command::new("cargo");
-    cmd.args(&["run", "--example", "spawn_window", "--"])
-        .args(&["--title", title, "--icon", icon_path])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+// /// Spawn a test window with an icon
+// ///
+// /// # Arguments
+// /// * `title` - The window title to set
+// /// * `icon_path` - Path to the icon file
+// ///
+// /// # Returns
+// /// A `Child` process handle for the spawned window
+// pub fn spawn_test_window_with_icon(
+//     title: &str,
+//     icon_path: &str,
+// ) -> Result<Child, Box<dyn std::error::Error>> {
+//     let mut cmd = Command::new("cargo");
+//     cmd.args(&["run", "--example", "spawn_window", "--"])
+//         .args(&["--title", title, "--icon", icon_path])
+//         .stdin(Stdio::null())
+//         .stdout(Stdio::piped())
+//         .stderr(Stdio::piped());
 
-    let child = cmd.spawn()?;
+//     let child = cmd.spawn()?;
 
-    // Give the window time to appear
-    std::thread::sleep(Duration::from_millis(500));
+//     // Give the window time to appear
+//     std::thread::sleep(Duration::from_millis(500));
 
-    Ok(child)
-}
+//     Ok(child)
+// }
 
 /// Focus a window (platform-specific implementation)
 ///
@@ -88,7 +88,7 @@ fn focus_window_linux(child: &mut Child) -> Result<(), Box<dyn std::error::Error
 
     // Use wmctrl to focus the window by PID if available
     if Command::new("wmctrl").arg("-l").output().is_ok() {
-        let output = Command::new("wmctrl").args(&["-l", "-p"]).output()?;
+        let output = Command::new("wmctrl").args(["-l", "-p"]).output()?;
 
         let output_str = String::from_utf8_lossy(&output.stdout);
 
@@ -101,7 +101,7 @@ fn focus_window_linux(child: &mut Child) -> Result<(), Box<dyn std::error::Error
                         let window_id = parts[0];
                         // Focus the window
                         Command::new("wmctrl")
-                            .args(&["-i", "-a", window_id])
+                            .args(["-i", "-a", window_id])
                             .output()?;
                         return Ok(());
                     }
@@ -112,14 +112,14 @@ fn focus_window_linux(child: &mut Child) -> Result<(), Box<dyn std::error::Error
     // Fallback: use xdotool if available
     if Command::new("xdotool").arg("--version").status()?.success() {
         let ids = Command::new("xdotool")
-            .args(&["search", "--pid", &pid.to_string()])
+            .args(["search", "--pid", &pid.to_string()])
             .output()?;
         if !ids.status.success() {
             return Err("xdotool search failed".into());
         }
         if let Some(id) = String::from_utf8_lossy(&ids.stdout).lines().next() {
             let status = Command::new("xdotool")
-                .args(&["windowactivate", id])
+                .args(["windowactivate", id])
                 .status()?;
             if status.success() {
                 return Ok(());
@@ -200,7 +200,7 @@ fn get_focused_window_linux() -> Result<ferrous_focus::FocusedWindow, Box<dyn st
 
     // Try to get the focused window using xdotool
     if let Ok(output) = Command::new("xdotool")
-        .args(&["getwindowfocus", "getwindowname"])
+        .args(["getwindowfocus", "getwindowname"])
         .output()
     {
         let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -268,7 +268,7 @@ pub fn setup_test_environment() -> Result<(), Box<dyn std::error::Error>> {
 /// Cleanup function to terminate child processes
 pub fn cleanup_child_process(mut child: Child) -> Result<(), Box<dyn std::error::Error>> {
     // Try to terminate gracefully first
-    if let Err(_) = child.kill() {
+    if child.kill().is_err() {
         // If kill fails, the process might have already exited
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new example program that tracks the currently focused application window and saves its icon as a PNG file, with logging and graceful shutdown support.

- **Bug Fixes**
  - Improved icon extraction on Linux by correctly parsing window icon data, ensuring accurate icon retrieval and better error reporting.

- **Chores**
  - Updated `.gitignore` to exclude files in the recorded icons directory except for a placeholder file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->